### PR TITLE
Add optional max-depth feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 *.swp
 .DS_Store
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,3 @@
-[root]
-name = "oak"
-version = "0.2.0"
-dependencies = [
- "clap 2.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "globset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.5.3"
@@ -149,6 +140,15 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "oak"
+version = "0.2.0"
+dependencies = [
+ "clap 2.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
Adds an option `-L` / `--level` which limits the depth to which oak will traverse the filesystem. 